### PR TITLE
Shared drive support no move drive

### DIFF
--- a/docker/test-values.yml
+++ b/docker/test-values.yml
@@ -85,7 +85,7 @@ cronjob:
     - name: reconcile-shared-drives
       schedule: "5 9 * * *"
       command: ["/scripts/management_command.sh"]
-      args: ["reconcile_shared_drives"]
+      args: ["reconcile_shared_drives", "--no-move-drive"]
 daemon:
   enabled: true
   daemons:

--- a/endorsement/dao/shared_drive.py
+++ b/endorsement/dao/shared_drive.py
@@ -57,8 +57,10 @@ def sync_quota_from_subscription(drive_id):
 
         state = record.subscription.state
         if state == ITBillSubscription.SUBSCRIPTION_DEPLOYED:
-            logger.info(f"sync: Shared drive {drive_id}"
-                        f" subscription not deployed: {state}")
+            logger.info(
+                f"sync: Shared drive {drive_id}"
+                f" subscription not deployed: {state}"
+            )
             return
 
         default_quota = get_default_quota()
@@ -117,10 +119,7 @@ def load_shared_drive_record(a: GoogleDriveState, is_seen):
     shared_drive = upsert_shared_drive(a, is_seen)
     shared_drive_record, _ = SharedDriveRecord.objects.get_or_create(
         shared_drive=shared_drive,
-        defaults={
-            "datetime_accepted": now,
-            "datetime_created": now
-        }
+        defaults={"datetime_accepted": now, "datetime_created": now},
     )
 
     # backfill if missed
@@ -145,7 +144,7 @@ def upsert_shared_drive(a: GoogleDriveState, is_seen):
             defaults={
                 "drive_name": a.drive_name,
                 "drive_quota": drive_quota,
-                "drive_usage": a.size_gigabytes
+                "drive_usage": a.size_gigabytes,
             },
         )
 
@@ -301,8 +300,10 @@ def reconcile_drive_quota(sdr: SharedDriveRecord, *, no_subscription_quota):
     )
 
     if quota_actual != quota_correct:
-        logger.info(f"reconcile: set drive {sdr.shared_drive.drive_id} "
-                    f"quota from {quota_actual} to {quota_correct} GB")
+        logger.info(
+            f"reconcile: set drive {sdr.shared_drive.drive_id} "
+            f"quota from {quota_actual} to {quota_correct} GB"
+        )
         # TODO: error handling!
         set_drive_quota(
             drive_id=sdr.shared_drive.drive_id, quota=quota_correct
@@ -310,8 +311,10 @@ def reconcile_drive_quota(sdr: SharedDriveRecord, *, no_subscription_quota):
         drive_quota.quota_limit = quota_correct
         drive_quota.save()
     else:
-        logger.debug(f"reconcile: drive {sdr.shared_drive.drive_id} "
-                     f"unchanged quota {quota_actual} GB")
+        logger.debug(
+            f"reconcile: drive {sdr.shared_drive.drive_id} "
+            f"unchanged quota {quota_actual} GB"
+        )
 
 
 class Reconciler:
@@ -409,8 +412,8 @@ class Reconciler:
                 try:
                     member = get_shared_drive_member(gds)
                 except (
-                        SharedDriveNonPrivilegedMember,
-                        UnrecognizedUWNetid
+                    SharedDriveNonPrivilegedMember,
+                    UnrecognizedUWNetid,
                 ) as ex:
                     logger.info(f"skip member: {ex}")
                     pass

--- a/endorsement/management/commands/reconcile_shared_drives.py
+++ b/endorsement/management/commands/reconcile_shared_drives.py
@@ -10,6 +10,14 @@ from endorsement.dao.shared_drive import Reconciler
 class Command(BaseCommand):
     help = "Loop over all shared drives verifying lifecycle and subscriptions"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-move-drive',
+            action='store_true',
+            default=False,
+            help="If provided no drives will be moved.",
+        )
+
     def handle(self, *args, **options):
         logging.getLogger().setLevel(logging.INFO)
-        Reconciler().reconcile()
+        Reconciler(options['no_move_drive']).reconcile()

--- a/endorsement/test/dao/test_shared_drive.py
+++ b/endorsement/test/dao/test_shared_drive.py
@@ -139,7 +139,7 @@ class BaseReconcilerTest(TestDao):
         In addition one can specify the methods to do something else. See
         https://docs.python.org/3/library/unittest.mock.html#order-of-precedence-of-side-effect-return-value-and-wraps
         """
-        instance = Reconciler()
+        instance = Reconciler(no_move_drive=False)
 
         # wrap all methods
         to_wrap = inspect.getmembers(instance, predicate=inspect.ismethod)


### PR DESCRIPTION
This adds an optional `--no-move-drive` flag to `reconcile_shared_drives` such that drives are not moved